### PR TITLE
added GenerateCvu function

### DIFF
--- a/pkg/utils/alias.go
+++ b/pkg/utils/alias.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
@@ -31,6 +32,23 @@ func GenerateAlias() string {
 		selectedWords = append(selectedWords, pick)
 	}
 	items := strings.Join(selectedWords, ".")
-	// fmt.Println(strings.ToUpper(items))
 	return strings.ToUpper(items)
+}
+
+func GenerateCvu() string {
+	rand.Seed(time.Now().UnixNano())
+
+	// generates a random number up to the int64 limit
+	firstMax := 999999999999999999
+	firstMin := 100000000000000000
+	firstNum := rand.Intn(firstMax-firstMin) + firstMin
+
+	// generates a new random number to complete the 22 digits
+	secMax := 9999
+	secMin := 1000
+	secNum := rand.Intn(secMax-secMin) + secMin
+
+	// concatenates the given numbers
+	cvu := string(fmt.Sprint(firstNum) + fmt.Sprint(secNum))
+	return cvu
 }


### PR DESCRIPTION
Se agrega la funcionalidad de generar un cvu random.
- Se dividio la funcion en 2 partes ya que el limite para int64 era menor a los 22 digitos por lo que no permitia devolverlo completo
- La funcion devuelve un string, no int. No es opcional ya que es imposible devolver un valor numerico mayor al permitido por los tipos de datos nativos de Go.
- Hay que cambiar el tipo de dato en la entidad de la base de datos y del modelo de CVU a "string".